### PR TITLE
adding docs for installing packages to pwa container

### DIFF
--- a/docs/addingPackages.md
+++ b/docs/addingPackages.md
@@ -1,0 +1,7 @@
+# Adding Packages
+
+To intsall a package into the PWA container, you have to use:
+```
+docker compose exec pwa \
+pnpm install <package-name>
+```


### PR DESCRIPTION
This pull request includes a new section in the `docs/addingPackages.md` file to provide instructions on how to install a package into the PWA container.

Documentation update:

* [`docs/addingPackages.md`](diffhunk://#diff-f0ae3d93b6604aed4f10cf12d2db4d3eeca8d54c0534a4e083a86b60a2169b2eR1-R7): Added instructions for installing a package using `docker compose exec pwa` and `pnpm install`.